### PR TITLE
Replace offset with skip

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -77,7 +77,7 @@ async function paginateQueryBuilder<T>(
 
   const [items, total] = await queryBuilder
     .take(limit)
-    .offset(page * limit)
+    .skip(page * limit)
     .getManyAndCount();
 
   return createPaginationObject<T>(items, total, page, limit, route);


### PR DESCRIPTION
using skip instead of offset, since most of the time a queryBuilder has a joined table