### PR TITLE
feat: added condition to return empty of pages less than 1

### DIFF
--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -188,4 +188,16 @@ describe('Test paginate function', () => {
 
     expect(results.links.next).toBe('/test?test=test&page=2&limit=4');
   });
+
+  it('when page is 0, return empty pagination object', async () => {
+    const mockRepository = new MockRepository(10);
+
+    let results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: 0,
+      route: '/test?test=test',
+    });
+
+    expect(results.items.length).toBe(0);
+  });
 });

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -73,7 +73,7 @@ function createPaginationObject<T>(
 }
 
 function resolveOptions(options: IPaginationOptions): [number, number, string] {
-  const page = options.page < 1 ? 1 : options.page;
+  const page = options.page;
   const limit = options.limit;
   const route = options.route;
 
@@ -86,6 +86,10 @@ async function paginateRepository<T>(
   searchOptions?: FindConditions<T> | FindManyOptions<T>,
 ): Promise<Pagination<T>> {
   const [page, limit, route] = resolveOptions(options);
+
+  if (page < 1) {
+    return createPaginationObject([], 0, page, limit, route);
+  }
 
   const [items, total] = await repository.findAndCount({
     skip: limit * (page - 1),


### PR DESCRIPTION
If page requested is less than 0, return a null pagination object #129 #86 