### PR TITLE
fixing name of the orderBy function;

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export class CatService {
 
   async paginate(options: IPaginationOptions): Promise<Pagination<CatEntity>> {
     const queryBuilder = this.repository.createQueryBuilder('c');
-    queryBuilder.order('c.name', 'DESC'); // Or whatever you need to do
+    queryBuilder.orderBy('c.name', 'DESC'); // Or whatever you need to do
 
     return paginate<CatEntity>(queryBuilder, options);
   }


### PR DESCRIPTION
It looks like the correct name of the function is `orderBy` instead of `order`: https://typeorm.delightful.studio/classes/_query_builder_selectquerybuilder_.selectquerybuilder.html#orderby