### PR TITLE
Paginate raw type change proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ return new Pagination(
 
 ```typescript
 const queryBuilder = this.repository
-  .createQueryBuilder('c')
+  .createQueryBuilder<{ type: string; totalLives: string }>('c')
   .select('c.type', 'type')
   .addSelect('SUM(c.lives)', 'totalLives')
   .groupBy('c.type')
   .orderBy('c.type', 'DESC'); // Or whatever you need to do
 
-return paginateRaw<{ type: string: totalLives: string }>(queryBuilder, options);
+return paginateRaw(queryBuilder, options);
 ```

--- a/src/__tests__/paginate-raw.spec.ts
+++ b/src/__tests__/paginate-raw.spec.ts
@@ -13,7 +13,7 @@ interface RawQueryResult {
 describe('Test paginateRaw function', () => {
   let app: TestingModule;
   let connection: Connection;
-  let queryBuilder: SelectQueryBuilder<TestEntity>;
+  let queryBuilder: SelectQueryBuilder<RawQueryResult>;
 
   let results: Pagination<RawQueryResult>;
 
@@ -36,7 +36,10 @@ describe('Test paginateRaw function', () => {
       ],
     }).compile();
     connection = app.get(getConnectionToken());
-    queryBuilder = connection.createQueryBuilder(TestEntity, 't');
+    queryBuilder = connection.createQueryBuilder<RawQueryResult>(
+      TestEntity,
+      't',
+    );
 
     // Insert some registries on database
     for (let i = 1; i <= totalItems; i++) {
@@ -96,7 +99,7 @@ describe('Test paginateRaw function', () => {
           .addSelect('SUM(t.id)', 'sum')
           .groupBy('t.id');
 
-        results = await paginateRaw<RawQueryResult>(queryBuilder, {
+        results = await paginateRaw(queryBuilder, {
           ...options,
           route: 'http://example.com/something',
         });

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -28,7 +28,7 @@ export async function paginate<T>(
 }
 
 export async function paginateRaw<T>(
-  queryBuilder: SelectQueryBuilder<any>,
+  queryBuilder: SelectQueryBuilder<T>,
   options: IPaginationOptions,
 ): Promise<Pagination<T>> {
   const [page, limit, route] = resolveOptions(options);


### PR DESCRIPTION
Hi @bashleigh ,

During my usage of the new feature `paginateRaw` I noticed that perhaps it makes more sense that the `paginateRaw` helper inherits the type of the query builder. E.g.:

Currently interface is defined on `paginateRaw` method:

```ts
const queryBuilder = this.repository
  .createQueryBuilder('c')
  .select('c.type', 'type')
  .addSelect('SUM(c.lives)', 'totalLives')
  .groupBy('c.type')
  .orderBy('c.type', 'DESC');

return paginateRaw<{ type: string: totalLives: string }>(queryBuilder, options); // Typed here
```

The proposal is change to inherit from query builder:

```ts
const queryBuilder = this.repository
  .createQueryBuilder<{ type: string; totalLives: string }>('c') // Typed here
  .select('c.type', 'type')
  .addSelect('SUM(c.lives)', 'totalLives')
  .groupBy('c.type')
  .orderBy('c.type', 'DESC'); // Or whatever you need to do

return paginateRaw(queryBuilder, options);
```

For me, in cases where query builder is defined in another method it makes more sense to inherit the same interface.

On the other hand,  the `getRawMany` method don't inherits the queryBuilder's type. So, I don't know what's the correct behavior... 😕 

Please, let me know what you think about.
