### PR TITLE
 Handle string inputs for `page` and `limit`

### DIFF
--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -127,6 +127,57 @@ describe('Test paginate function', () => {
     );
   });
 
+  it('returns page 2 as the next one for a input page of "1"', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: "4" as any,
+      page: "1" as any,
+      route: 'http://example.com/something',
+    });
+
+    expect(results.links.first).toBe('http://example.com/something?limit=4');
+    expect(results.links.previous).toBe(
+      '',
+    );
+    expect(results.links.next).toBe('http://example.com/something?page=11&limit=4'); // TODO
+    expect(results.links.last).toBe(
+      'http://example.com/something?page=3&limit=4',
+    );
+  });
+
+  it('replaces a bad limit with the default of 10', async () => {
+    const mockRepository = new MockRepository(15);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: "x" as any,
+      page: 2,
+      route: 'http://example.com/something',
+    });
+
+    expect(results.items.length).toBe(0); // TODO
+    expect(results.links.first).toBe('http://example.com/something?limit=x'); // TODO
+    expect(results.links.previous).toBe('http://example.com/something?page=1&limit=x'); // TODO
+    expect(results.links.next).toBe('');
+    expect(results.links.last).toBe('http://example.com/something?page=NaN&limit=x'); // TODO
+  });
+
+  it('replaces a bad page with the default of 1', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: "x" as any,
+      route: 'http://example.com/something',
+    });
+
+    expect(results.items.length).toBe(0); // TODO
+    expect(results.links.first).toBe('http://example.com/something?limit=4');
+    expect(results.links.previous).toBe('');
+    expect(results.links.next).toBe(''); // TODO
+    expect(results.links.last).toBe('http://example.com/something?page=3&limit=4');
+  });
+
   it('Can pass FindConditions', async () => {
     const mockRepository = new MockRepository(2);
 
@@ -199,5 +250,9 @@ describe('Test paginate function', () => {
     });
 
     expect(results.items.length).toBe(0);
+    expect(results.links.first).toBe('/test?test=test&limit=4');
+    expect(results.links.previous).toBe('');
+    expect(results.links.next).toBe('');
+    expect(results.links.last).toBe('/test?test=test&page=0&limit=4'); // TODO
   });
 });

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -131,16 +131,16 @@ describe('Test paginate function', () => {
     const mockRepository = new MockRepository(10);
 
     const results = await paginate<Entity>(mockRepository, {
-      limit: "4",
-      page: "1",
+      limit: '4',
+      page: '1',
       route: 'http://example.com/something',
     });
 
     expect(results.links.first).toBe('http://example.com/something?limit=4');
-    expect(results.links.previous).toBe(
-      '',
+    expect(results.links.previous).toBe('');
+    expect(results.links.next).toBe(
+      'http://example.com/something?page=2&limit=4',
     );
-    expect(results.links.next).toBe('http://example.com/something?page=2&limit=4');
     expect(results.links.last).toBe(
       'http://example.com/something?page=3&limit=4',
     );
@@ -149,33 +149,57 @@ describe('Test paginate function', () => {
   it('replaces a bad limit with the default of 10', async () => {
     const mockRepository = new MockRepository(15);
 
+    const consoleMock = jest
+      .spyOn(console, 'warn')
+      .mockImplementationOnce(() => {});
+
     const results = await paginate<Entity>(mockRepository, {
-      limit: "x",
+      limit: 'x',
       page: 2,
       route: 'http://example.com/something',
     });
 
     expect(results.items.length).toBe(5);
     expect(results.links.first).toBe('http://example.com/something?limit=10');
-    expect(results.links.previous).toBe('http://example.com/something?page=1&limit=10');
+    expect(results.links.previous).toBe(
+      'http://example.com/something?page=1&limit=10',
+    );
     expect(results.links.next).toBe('');
-    expect(results.links.last).toBe('http://example.com/something?page=2&limit=10');
+    expect(results.links.last).toBe(
+      'http://example.com/something?page=2&limit=10',
+    );
+    expect(consoleMock).toHaveBeenCalledWith(
+      'Provided limit query parameter was processed as NaN, please validate your query input! Falling back to default = ',
+      10,
+    );
   });
 
   it('replaces a bad page with the default of 1', async () => {
     const mockRepository = new MockRepository(10);
 
+    const consoleMock = jest
+      .spyOn(console, 'warn')
+      .mockImplementationOnce(() => {});
+
     const results = await paginate<Entity>(mockRepository, {
       limit: 4,
-      page: "x",
+      page: 'x',
       route: 'http://example.com/something',
     });
 
     expect(results.items.length).toBe(4);
     expect(results.links.first).toBe('http://example.com/something?limit=4');
     expect(results.links.previous).toBe('');
-    expect(results.links.next).toBe('http://example.com/something?page=2&limit=4');
-    expect(results.links.last).toBe('http://example.com/something?page=3&limit=4');
+    expect(results.links.next).toBe(
+      'http://example.com/something?page=2&limit=4',
+    );
+    expect(results.links.last).toBe(
+      'http://example.com/something?page=3&limit=4',
+    );
+    expect(consoleMock).toHaveBeenCalledWith(
+      'Provided page query parameter was processed as NaN, please validate your query input! Falling back to default = ',
+      1,
+    );
   });
 
   it('Can pass FindConditions', async () => {

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -131,8 +131,8 @@ describe('Test paginate function', () => {
     const mockRepository = new MockRepository(10);
 
     const results = await paginate<Entity>(mockRepository, {
-      limit: "4" as any,
-      page: "1" as any,
+      limit: "4",
+      page: "1",
       route: 'http://example.com/something',
     });
 
@@ -140,7 +140,7 @@ describe('Test paginate function', () => {
     expect(results.links.previous).toBe(
       '',
     );
-    expect(results.links.next).toBe('http://example.com/something?page=11&limit=4'); // TODO
+    expect(results.links.next).toBe('http://example.com/something?page=2&limit=4');
     expect(results.links.last).toBe(
       'http://example.com/something?page=3&limit=4',
     );
@@ -150,16 +150,16 @@ describe('Test paginate function', () => {
     const mockRepository = new MockRepository(15);
 
     const results = await paginate<Entity>(mockRepository, {
-      limit: "x" as any,
+      limit: "x",
       page: 2,
       route: 'http://example.com/something',
     });
 
-    expect(results.items.length).toBe(0); // TODO
-    expect(results.links.first).toBe('http://example.com/something?limit=x'); // TODO
-    expect(results.links.previous).toBe('http://example.com/something?page=1&limit=x'); // TODO
+    expect(results.items.length).toBe(5);
+    expect(results.links.first).toBe('http://example.com/something?limit=10');
+    expect(results.links.previous).toBe('http://example.com/something?page=1&limit=10');
     expect(results.links.next).toBe('');
-    expect(results.links.last).toBe('http://example.com/something?page=NaN&limit=x'); // TODO
+    expect(results.links.last).toBe('http://example.com/something?page=2&limit=10');
   });
 
   it('replaces a bad page with the default of 1', async () => {
@@ -167,14 +167,14 @@ describe('Test paginate function', () => {
 
     const results = await paginate<Entity>(mockRepository, {
       limit: 4,
-      page: "x" as any,
+      page: "x",
       route: 'http://example.com/something',
     });
 
-    expect(results.items.length).toBe(0); // TODO
+    expect(results.items.length).toBe(4);
     expect(results.links.first).toBe('http://example.com/something?limit=4');
     expect(results.links.previous).toBe('');
-    expect(results.links.next).toBe(''); // TODO
+    expect(results.links.next).toBe('http://example.com/something?page=2&limit=4');
     expect(results.links.last).toBe('http://example.com/something?page=3&limit=4');
   });
 
@@ -253,6 +253,6 @@ describe('Test paginate function', () => {
     expect(results.links.first).toBe('/test?test=test&limit=4');
     expect(results.links.previous).toBe('');
     expect(results.links.next).toBe('');
-    expect(results.links.last).toBe('/test?test=test&page=0&limit=4'); // TODO
+    expect(results.links.last).toBe('');
   });
 });

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -169,8 +169,7 @@ describe('Test paginate function', () => {
       'http://example.com/something?page=2&limit=10',
     );
     expect(consoleMock).toHaveBeenCalledWith(
-      'Provided limit query parameter was processed as NaN, please validate your query input! Falling back to default = ',
-      10,
+      'Query parameter "limit" with value "x" was resolved as "NaN", please validate your query input! Falling back to default "10".',
     );
   });
 
@@ -197,8 +196,7 @@ describe('Test paginate function', () => {
       'http://example.com/something?page=3&limit=4',
     );
     expect(consoleMock).toHaveBeenCalledWith(
-      'Provided page query parameter was processed as NaN, please validate your query input! Falling back to default = ',
-      1,
+      'Query parameter "page" with value "x" was resolved as "NaN", please validate your query input! Falling back to default "1".',
     );
   });
 

--- a/src/create-pagination.ts
+++ b/src/create-pagination.ts
@@ -13,7 +13,7 @@ export function createPaginationObject<T>(
   const hasFirstPage = route;
   const hasPreviousPage = route && currentPage > 1;
   const hasNextPage = route && currentPage < totalPages;
-  const hasLastPage = route;
+  const hasLastPage = totalPages > 0;
 
   const symbol = route && new RegExp(/\?/).test(route) ? '&' : '?';
 

--- a/src/create-pagination.ts
+++ b/src/create-pagination.ts
@@ -13,7 +13,7 @@ export function createPaginationObject<T>(
   const hasFirstPage = route;
   const hasPreviousPage = route && currentPage > 1;
   const hasNextPage = route && currentPage < totalPages;
-  const hasLastPage = totalPages > 0;
+  const hasLastPage = route && totalPages > 0;
 
   const symbol = route && new RegExp(/\?/).test(route) ? '&' : '?';
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -2,11 +2,11 @@ export interface IPaginationOptions {
   /**
    * the amount of items to be requested per page
    */
-  limit: number;
+  limit: number | string;
   /**
    * the page that is requested
    */
-  page: number;
+  page: number | string;
   /**
    * a babasesic route for generating links (i.e., WITHOUT query params)
    */

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -87,14 +87,13 @@ function resolveNumericOption(
   const value = options[key];
   const resolvedValue = Number(value);
 
-  if (isNaN(resolvedValue)) {
-    console.warn(
-      `Query parameter "${key}" with value "${value}" was resolved as "${resolvedValue}", please validate your query input! Falling back to default "${defaultValue}".`,
-    );
-    return defaultValue;
-  }
+  if (Number.isInteger(resolvedValue) && resolvedValue >= 0)
+    return resolvedValue;
 
-  return resolvedValue;
+  console.warn(
+    `Query parameter "${key}" with value "${value}" was resolved as "${resolvedValue}", please validate your query input! Falling back to default "${defaultValue}".`,
+  );
+  return defaultValue;
 }
 
 async function paginateRepository<T>(

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -69,11 +69,33 @@ export async function paginateRawAndEntities<T>(
 }
 
 function resolveOptions(options: IPaginationOptions): [number, number, string] {
-  const page = options.page;
-  const limit = options.limit;
+  const page = resolvePage(options.page);
+  const limit = resolveLimit(options.limit);
   const route = options.route;
 
   return [page, limit, route];
+}
+
+function resolvePage(page: number | string): number {
+  const resolvedPage = Number(page);
+
+  if (isNaN(resolvedPage)) {
+    // TODO: console.log
+    return 1;
+  } 
+
+  return resolvedPage;
+}
+
+function resolveLimit(limit: number | string): number {
+  const resolvedLimit = Number(limit);
+
+  if (isNaN(resolvedLimit)) {
+    // TODO: console.log
+    return 10;
+  } 
+
+  return resolvedLimit;
 }
 
 async function paginateRepository<T>(

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -8,6 +8,9 @@ import { Pagination } from './pagination';
 import { IPaginationOptions } from './interfaces';
 import { createPaginationObject } from './create-pagination';
 
+const DEFAULT_LIMIT = 10;
+const DEFAULT_PAGE = 1;
+
 export async function paginate<T>(
   repository: Repository<T>,
   options: IPaginationOptions,
@@ -80,9 +83,12 @@ function resolvePage(page: number | string): number {
   const resolvedPage = Number(page);
 
   if (isNaN(resolvedPage)) {
-    // TODO: console.log
-    return 1;
-  } 
+    console.warn(
+      'Provided page query parameter was processed as NaN, please validate your query input! Falling back to default = ',
+      DEFAULT_PAGE,
+    );
+    return DEFAULT_PAGE;
+  }
 
   return resolvedPage;
 }
@@ -91,9 +97,12 @@ function resolveLimit(limit: number | string): number {
   const resolvedLimit = Number(limit);
 
   if (isNaN(resolvedLimit)) {
-    // TODO: console.log
-    return 10;
-  } 
+    console.warn(
+      'Provided limit query parameter was processed as NaN, please validate your query input! Falling back to default = ',
+      DEFAULT_LIMIT,
+    );
+    return DEFAULT_LIMIT;
+  }
 
   return resolvedLimit;
 }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -72,39 +72,29 @@ export async function paginateRawAndEntities<T>(
 }
 
 function resolveOptions(options: IPaginationOptions): [number, number, string] {
-  const page = resolvePage(options.page);
-  const limit = resolveLimit(options.limit);
+  const page = resolveNumericOption(options, 'page', DEFAULT_PAGE);
+  const limit = resolveNumericOption(options, 'limit', DEFAULT_LIMIT);
   const route = options.route;
 
   return [page, limit, route];
 }
 
-function resolvePage(page: number | string): number {
-  const resolvedPage = Number(page);
+function resolveNumericOption(
+  options: IPaginationOptions,
+  key: 'page' | 'limit',
+  defaultValue: number,
+): number {
+  const value = options[key];
+  const resolvedValue = Number(value);
 
-  if (isNaN(resolvedPage)) {
+  if (isNaN(resolvedValue)) {
     console.warn(
-      'Provided page query parameter was processed as NaN, please validate your query input! Falling back to default = ',
-      DEFAULT_PAGE,
+      `Query parameter "${key}" with value "${value}" was resolved as "${resolvedValue}", please validate your query input! Falling back to default "${defaultValue}".`,
     );
-    return DEFAULT_PAGE;
+    return defaultValue;
   }
 
-  return resolvedPage;
-}
-
-function resolveLimit(limit: number | string): number {
-  const resolvedLimit = Number(limit);
-
-  if (isNaN(resolvedLimit)) {
-    console.warn(
-      'Provided limit query parameter was processed as NaN, please validate your query input! Falling back to default = ',
-      DEFAULT_LIMIT,
-    );
-    return DEFAULT_LIMIT;
-  }
-
-  return resolvedLimit;
+  return resolvedValue;
 }
 
 async function paginateRepository<T>(


### PR DESCRIPTION
Following on from https://github.com/nestjsx/nestjs-typeorm-paginate/pull/424

The first commit (https://github.com/nestjsx/nestjs-typeorm-paginate/commit/4908ba115a8a670e8862698aeabb897aa78c7f99) shows what the test outputs are without making changes, so we can see exactly what behaviour will change.

Summary:

* Invalid input for page and limit default to 1 and 10 respectively.
* Invalid input results in a call to console.warn
* No warning will occur with valid string inputs e.g. "42"
