### PR TITLE
default IPaginationOptions generic type

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,4 @@
-export interface IPaginationOptions<CustomMetaType> {
+export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
   /**
    * the amount of items to be requested per page
    */


### PR DESCRIPTION
Added quick optional that looked to match the surrounding defaults around the various `paginate(...)` method overloads. 

Should make it backwards compatible to previous versions prior to these changes, did not update docs to show new extended usages.

Closes #507 