### PR TITLE
Add custom query string labels at meta links

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,14 +335,14 @@ This will result in the above returning `CustomPaginationMeta` in the `meta` pro
 
 ## Custom links query params labels
 
-If you want to alter the `limit` and/or `page` labels in meta links, then use extra `configuration` in the options like so
+If you want to alter the `limit` and/or `page` labels in meta links, then use `routingLabels` in the options like so
 
 ```ts
 
 return paginate<MyEntity>(this.repository, { 
   page,
   limit,
-  configuration: {
+  routingLabels: {
     limitLabel: 'page-size', // default: limit
     pageLabel: 'current-page', //default: page
   }

--- a/README.md
+++ b/README.md
@@ -331,3 +331,22 @@ return paginate<MyEntity, CustomPaginationMeta>(this.repository, {
 ```
 
 This will result in the above returning `CustomPaginationMeta` in the `meta` property instead of the default `IPaginationMeta`.
+
+
+## Custom links query params labels
+
+If you want to alter the `limit` and/or `page` labels in meta links, then use extra `configuration` in the options like so
+
+```ts
+
+return paginate<MyEntity>(this.repository, { 
+  page,
+  limit,
+  configuration: {
+    limitLabel: 'page-size', // default: limit
+    pageLabel: 'current-page', //default: page
+  }
+ });
+```
+
+This will result links like `http://example.com/something?current-page=1&page-size=3`. 

--- a/src/__tests__/paginate-raw-and-entities.spec.ts
+++ b/src/__tests__/paginate-raw-and-entities.spec.ts
@@ -96,7 +96,7 @@ describe('Test paginateRawAndEntities function', () => {
       {
         limit: 3,
         page: 2,
-        configuration: { limitLabel: 'page-size', pageLabel: 'current-page' },
+        routingLabels: { limitLabel: 'page-size', pageLabel: 'current-page' },
       },
       {
         itemCount: 3,
@@ -113,7 +113,7 @@ describe('Test paginateRawAndEntities function', () => {
       },
     ],
     [
-      { limit: 3, page: 2, configuration: { limitLabel: 'page-size' } },
+      { limit: 3, page: 2, routingLabels: { limitLabel: 'page-size' } },
       {
         itemCount: 3,
         totalItems: 10,
@@ -129,7 +129,7 @@ describe('Test paginateRawAndEntities function', () => {
       },
     ],
     [
-      { limit: 3, page: 2, configuration: { pageLabel: 'current-page' } },
+      { limit: 3, page: 2, routingLabels: { pageLabel: 'current-page' } },
       {
         itemCount: 3,
         totalItems: 10,

--- a/src/__tests__/paginate-raw-and-entities.spec.ts
+++ b/src/__tests__/paginate-raw-and-entities.spec.ts
@@ -92,6 +92,58 @@ describe('Test paginateRawAndEntities function', () => {
         last: `${TEST_ROUTE}?page=4&limit=3`,
       },
     ],
+    [
+      {
+        limit: 3,
+        page: 2,
+        configuration: { limitLabel: 'page-size', pageLabel: 'current-page' },
+      },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: `${TEST_ROUTE}?page-size=3`,
+        previous: `${TEST_ROUTE}?current-page=1&page-size=3`,
+        next: `${TEST_ROUTE}?current-page=3&page-size=3`,
+        last: `${TEST_ROUTE}?current-page=4&page-size=3`,
+      },
+    ],
+    [
+      { limit: 3, page: 2, configuration: { limitLabel: 'page-size' } },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: `${TEST_ROUTE}?page-size=3`,
+        previous: `${TEST_ROUTE}?page=1&page-size=3`,
+        next: `${TEST_ROUTE}?page=3&page-size=3`,
+        last: `${TEST_ROUTE}?page=4&page-size=3`,
+      },
+    ],
+    [
+      { limit: 3, page: 2, configuration: { pageLabel: 'current-page' } },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: `${TEST_ROUTE}?limit=3`,
+        previous: `${TEST_ROUTE}?current-page=1&limit=3`,
+        next: `${TEST_ROUTE}?current-page=3&limit=3`,
+        last: `${TEST_ROUTE}?current-page=4&limit=3`,
+      },
+    ],
   ])(
     'For options \n%j\n should return meta \n%j\n and links \n%j',
     (options, meta, links) => {

--- a/src/__tests__/paginate-raw.spec.ts
+++ b/src/__tests__/paginate-raw.spec.ts
@@ -94,6 +94,58 @@ describe('Test paginateRaw function', () => {
         last: 'http://example.com/something?page=4&limit=3',
       },
     ],
+    [
+      {
+        limit: 3,
+        page: 2,
+        configuration: { limitLabel: 'page-size', pageLabel: 'current-page' },
+      },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: 'http://example.com/something?page-size=3',
+        previous: 'http://example.com/something?current-page=1&page-size=3',
+        next: 'http://example.com/something?current-page=3&page-size=3',
+        last: 'http://example.com/something?current-page=4&page-size=3',
+      },
+    ],
+    [
+      { limit: 3, page: 2, configuration: { limitLabel: 'page-size' } },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: 'http://example.com/something?page-size=3',
+        previous: 'http://example.com/something?page=1&page-size=3',
+        next: 'http://example.com/something?page=3&page-size=3',
+        last: 'http://example.com/something?page=4&page-size=3',
+      },
+    ],
+    [
+      { limit: 3, page: 2, configuration: { pageLabel: 'current-page' } },
+      {
+        itemCount: 3,
+        totalItems: 10,
+        itemsPerPage: 3,
+        totalPages: 4,
+        currentPage: 2,
+      },
+      {
+        first: 'http://example.com/something?limit=3',
+        previous: 'http://example.com/something?current-page=1&limit=3',
+        next: 'http://example.com/something?current-page=3&limit=3',
+        last: 'http://example.com/something?current-page=4&limit=3',
+      },
+    ],
   ])(
     'For options %j should return meta %j and links %j',
     (options, meta, links) => {

--- a/src/__tests__/paginate-raw.spec.ts
+++ b/src/__tests__/paginate-raw.spec.ts
@@ -98,7 +98,7 @@ describe('Test paginateRaw function', () => {
       {
         limit: 3,
         page: 2,
-        configuration: { limitLabel: 'page-size', pageLabel: 'current-page' },
+        routingLabels: { limitLabel: 'page-size', pageLabel: 'current-page' },
       },
       {
         itemCount: 3,
@@ -115,7 +115,7 @@ describe('Test paginateRaw function', () => {
       },
     ],
     [
-      { limit: 3, page: 2, configuration: { limitLabel: 'page-size' } },
+      { limit: 3, page: 2, routingLabels: { limitLabel: 'page-size' } },
       {
         itemCount: 3,
         totalItems: 10,
@@ -131,7 +131,7 @@ describe('Test paginateRaw function', () => {
       },
     ],
     [
-      { limit: 3, page: 2, configuration: { pageLabel: 'current-page' } },
+      { limit: 3, page: 2, routingLabels: { pageLabel: 'current-page' } },
       {
         itemCount: 3,
         totalItems: 10,

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -93,6 +93,83 @@ describe('Test paginate function', () => {
     );
   });
 
+  it('Routes return successfully using custom pageLabel and limitLabel', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: 2,
+      route: 'http://example.com/something',
+      configuration: {
+        limitLabel: 'page-size',
+        pageLabel: 'current-page',
+      },
+    });
+
+    expect(results.links.first).toBe(
+      'http://example.com/something?page-size=4',
+    );
+    expect(results.links.previous).toBe(
+      'http://example.com/something?current-page=1&page-size=4',
+    );
+    expect(results.links.next).toBe(
+      'http://example.com/something?current-page=3&page-size=4',
+    );
+    expect(results.links.last).toBe(
+      'http://example.com/something?current-page=3&page-size=4',
+    );
+  });
+
+  it('Routes return successfully using custom pageLabel', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: 2,
+      route: 'http://example.com/something',
+      configuration: {
+        pageLabel: 'current-page',
+      },
+    });
+
+    expect(results.links.first).toBe('http://example.com/something?limit=4');
+    expect(results.links.previous).toBe(
+      'http://example.com/something?current-page=1&limit=4',
+    );
+    expect(results.links.next).toBe(
+      'http://example.com/something?current-page=3&limit=4',
+    );
+    expect(results.links.last).toBe(
+      'http://example.com/something?current-page=3&limit=4',
+    );
+  });
+
+  it('Routes return successfully using custom limitLabel', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: 2,
+      route: 'http://example.com/something',
+      configuration: {
+        limitLabel: 'page-size',
+      },
+    });
+
+    expect(results.links.first).toBe(
+      'http://example.com/something?page-size=4',
+    );
+    expect(results.links.previous).toBe(
+      'http://example.com/something?page=1&page-size=4',
+    );
+    expect(results.links.next).toBe(
+      'http://example.com/something?page=3&page-size=4',
+    );
+    expect(results.links.last).toBe(
+      'http://example.com/something?page=3&page-size=4',
+    );
+  });
+
   it('Route previous return successfully blank', async () => {
     const mockRepository = new MockRepository(10);
 

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -100,7 +100,7 @@ describe('Test paginate function', () => {
       limit: 4,
       page: 2,
       route: 'http://example.com/something',
-      configuration: {
+      routingLabels: {
         limitLabel: 'page-size',
         pageLabel: 'current-page',
       },
@@ -127,7 +127,7 @@ describe('Test paginate function', () => {
       limit: 4,
       page: 2,
       route: 'http://example.com/something',
-      configuration: {
+      routingLabels: {
         pageLabel: 'current-page',
       },
     });
@@ -151,7 +151,7 @@ describe('Test paginate function', () => {
       limit: 4,
       page: 2,
       route: 'http://example.com/something',
-      configuration: {
+      routingLabels: {
         limitLabel: 'page-size',
       },
     });

--- a/src/create-pagination.ts
+++ b/src/create-pagination.ts
@@ -1,7 +1,7 @@
 import {
   IPaginationLinks,
   IPaginationMeta,
-  IPaginationOptionsConfiguration,
+  IPaginationOptionsRoutingLabels,
   ObjectLiteral,
 } from './interfaces';
 import { Pagination } from './pagination';
@@ -16,7 +16,7 @@ export function createPaginationObject<
   limit,
   route,
   metaTransformer,
-  configuration,
+  routingLabels,
 }: {
   items: T[];
   totalItems: number;
@@ -24,7 +24,7 @@ export function createPaginationObject<
   limit: number;
   route?: string;
   metaTransformer?: (meta: IPaginationMeta) => CustomMetaType;
-  configuration?: IPaginationOptionsConfiguration;
+  routingLabels?: IPaginationOptionsRoutingLabels;
 }): Pagination<T, CustomMetaType> {
   const totalPages = Math.ceil(totalItems / limit);
 
@@ -36,12 +36,12 @@ export function createPaginationObject<
   const symbol = route && new RegExp(/\?/).test(route) ? '&' : '?';
 
   const limitLabel =
-    configuration && configuration.limitLabel
-      ? configuration.limitLabel
+    routingLabels && routingLabels.limitLabel
+      ? routingLabels.limitLabel
       : 'limit';
 
   const pageLabel =
-    configuration && configuration.pageLabel ? configuration.pageLabel : 'page';
+    routingLabels && routingLabels.pageLabel ? routingLabels.pageLabel : 'page';
 
   const routes: IPaginationLinks = {
     first: hasFirstPage ? `${route}${symbol}${limitLabel}=${limit}` : '',

--- a/src/create-pagination.ts
+++ b/src/create-pagination.ts
@@ -1,4 +1,9 @@
-import { IPaginationLinks, IPaginationMeta, ObjectLiteral } from './interfaces';
+import {
+  IPaginationLinks,
+  IPaginationMeta,
+  IPaginationOptionsConfiguration,
+  ObjectLiteral,
+} from './interfaces';
 import { Pagination } from './pagination';
 
 export function createPaginationObject<
@@ -11,6 +16,7 @@ export function createPaginationObject<
   limit,
   route,
   metaTransformer,
+  configuration,
 }: {
   items: T[];
   totalItems: number;
@@ -18,6 +24,7 @@ export function createPaginationObject<
   limit: number;
   route?: string;
   metaTransformer?: (meta: IPaginationMeta) => CustomMetaType;
+  configuration?: IPaginationOptionsConfiguration;
 }): Pagination<T, CustomMetaType> {
   const totalPages = Math.ceil(totalItems / limit);
 
@@ -28,16 +35,28 @@ export function createPaginationObject<
 
   const symbol = route && new RegExp(/\?/).test(route) ? '&' : '?';
 
+  const limitLabel =
+    configuration && configuration.limitLabel
+      ? configuration.limitLabel
+      : 'limit';
+
+  const pageLabel =
+    configuration && configuration.pageLabel ? configuration.pageLabel : 'page';
+
   const routes: IPaginationLinks = {
-    first: hasFirstPage ? `${route}${symbol}limit=${limit}` : '',
+    first: hasFirstPage ? `${route}${symbol}${limitLabel}=${limit}` : '',
     previous: hasPreviousPage
-      ? `${route}${symbol}page=${currentPage - 1}&limit=${limit}`
+      ? `${route}${symbol}${pageLabel}=${
+          currentPage - 1
+        }&${limitLabel}=${limit}`
       : '',
     next: hasNextPage
-      ? `${route}${symbol}page=${currentPage + 1}&limit=${limit}`
+      ? `${route}${symbol}${pageLabel}=${
+          currentPage + 1
+        }&${limitLabel}=${limit}`
       : '',
     last: hasLastPage
-      ? `${route}${symbol}page=${totalPages}&limit=${limit}`
+      ? `${route}${symbol}${pageLabel}=${totalPages}&${limitLabel}=${limit}`
       : '',
   };
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -13,6 +13,11 @@ export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
   route?: string;
 
   metaTransformer?: (meta: IPaginationMeta) => CustomMetaType;
+
+  /**
+   * Others configurations
+   */
+  configuration?: IPaginationOptionsConfiguration;
 }
 
 export interface ObjectLiteral {
@@ -59,4 +64,16 @@ export interface IPaginationLinks {
    * a link to the "last" page
    */
   last?: string;
+}
+
+export interface IPaginationOptionsConfiguration {
+  /**
+   * the limit text to append in router string
+   */
+  limitLabel?: string;
+
+  /**
+   * the page text to append in router string
+   */
+  pageLabel?: string;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -15,9 +15,9 @@ export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
   metaTransformer?: (meta: IPaginationMeta) => CustomMetaType;
 
   /**
-   * Others configurations
+   * routingLabels for append in links (limit or/and page)
    */
-  configuration?: IPaginationOptionsConfiguration;
+  routingLabels?: IPaginationOptionsRoutingLabels;
 }
 
 export interface ObjectLiteral {
@@ -66,7 +66,7 @@ export interface IPaginationLinks {
   last?: string;
 }
 
-export interface IPaginationOptionsConfiguration {
+export interface IPaginationOptionsRoutingLabels {
   /**
    * the limit text to append in router string
    */

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -64,6 +64,7 @@ export async function paginateRaw<
     limit,
     route,
     metaTransformer: options.metaTransformer,
+    configuration: options.configuration,
   });
 }
 
@@ -94,6 +95,7 @@ export async function paginateRawAndEntities<
       limit,
       route,
       metaTransformer: options.metaTransformer,
+      configuration: options.configuration,
     }),
     itemObject.raw,
   ];
@@ -141,6 +143,7 @@ async function paginateRepository<T, CustomMetaType = IPaginationMeta>(
       limit,
       route,
       metaTransformer: options.metaTransformer,
+      configuration: options.configuration,
     });
   }
 
@@ -157,6 +160,7 @@ async function paginateRepository<T, CustomMetaType = IPaginationMeta>(
     limit,
     route,
     metaTransformer: options.metaTransformer,
+    configuration: options.configuration,
   });
 }
 
@@ -178,5 +182,6 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
     limit,
     route,
     metaTransformer: options.metaTransformer,
+    configuration: options.configuration,
   });
 }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -64,7 +64,7 @@ export async function paginateRaw<
     limit,
     route,
     metaTransformer: options.metaTransformer,
-    configuration: options.configuration,
+    routingLabels: options.routingLabels,
   });
 }
 
@@ -95,7 +95,7 @@ export async function paginateRawAndEntities<
       limit,
       route,
       metaTransformer: options.metaTransformer,
-      configuration: options.configuration,
+      routingLabels: options.routingLabels,
     }),
     itemObject.raw,
   ];
@@ -143,7 +143,7 @@ async function paginateRepository<T, CustomMetaType = IPaginationMeta>(
       limit,
       route,
       metaTransformer: options.metaTransformer,
-      configuration: options.configuration,
+      routingLabels: options.routingLabels,
     });
   }
 
@@ -160,7 +160,7 @@ async function paginateRepository<T, CustomMetaType = IPaginationMeta>(
     limit,
     route,
     metaTransformer: options.metaTransformer,
-    configuration: options.configuration,
+    routingLabels: options.routingLabels,
   });
 }
 
@@ -182,6 +182,6 @@ async function paginateQueryBuilder<T, CustomMetaType = IPaginationMeta>(
     limit,
     route,
     metaTransformer: options.metaTransformer,
-    configuration: options.configuration,
+    routingLabels: options.routingLabels,
   });
 }


### PR DESCRIPTION
I've added an extra configuration options to customize the `limit` and `page` labels at meta links.

It is good for localization (i18n), if someone needs to use a different language of English, for example.

What do you, guys, think about that?

Thank you!