### PR TITLE
Added support for NestJS 8.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepublish": "npm run format && npm run build"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.1.1 || ^5.6.2 || ^7.0.0",
+    "@nestjs/common": "^6.1.1 || ^5.6.2 || ^7.0.0 || ^8.0.0",
     "typeorm": "^0.2.12"
   },
   "jest": {


### PR DESCRIPTION
Fix bug resolve dependency while trying to use it with nestjs 8.x.x
```
Could not resolve dependency:
peer @nestjs/common@"^6.1.1 || ^5.6.2 || ^7.0.0" from nestjs-typeorm-paginate@2.5.3
```