### PR TITLE
Pass only `where` clause to the `count` query

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   },
   "version": "3.1.3",
   "dependencies": {
-    "chalk": "^5.0.0"
+    "chalk": "^4.1.2 <5.0.0"
   }
 }

--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -1,4 +1,3 @@
-import { async } from 'rxjs';
 import { Repository, FindManyOptions } from 'typeorm';
 
 export class MockRepository extends Repository<any> {
@@ -14,17 +13,17 @@ export class MockRepository extends Repository<any> {
     return [await this.find(options), await this.count(options)];
   };
 
-  find = async (options?: FindManyOptions<any>): Promise<any[]> => {
+  find = jest.fn(async (options?: FindManyOptions<any>): Promise<any[]> => {
     const startIndex = options.skip;
     const endIndex = startIndex + options.take;
 
     const localItems = this.items.slice(startIndex, endIndex);
     return localItems;
-  };
+  });
 
-  count = async (options?: FindManyOptions<any>): Promise<number> => {
+  count = jest.fn(async (options?: FindManyOptions<any>): Promise<number> => {
     return this.items.length;
-  };
+  });
 }
 
 export class Entity {}

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -19,6 +19,43 @@ describe('Test paginate function', () => {
     expect(results).toBeInstanceOf(Pagination);
   });
 
+  it('Calls to `find` & `count` should be correct (with explicit `where` clause)', async () => {
+    const mockRepository = new MockRepository(0);
+    const paginateOpts = {
+        limit: 8,
+        page: 2,
+      };
+      const findCondition = {
+          where: {foo: 'bar'},
+          orderBy: {
+              foo: 'ASC'
+          }
+      }
+
+    paginate<any>(mockRepository, {...paginateOpts}, findCondition);
+
+    expect(mockRepository.find).toHaveBeenCalledTimes(1);
+    expect(mockRepository.find).toHaveBeenCalledWith(expect.objectContaining({skip: 8, take: 8, ...findCondition}));
+    expect(mockRepository.count).toHaveBeenCalledTimes(1);
+    expect(mockRepository.count).toHaveBeenCalledWith(expect.objectContaining(findCondition.where));
+  });
+
+  it('Calls to `find` & `count` should be correct (with implicit `where` clause)', async () => {
+    const mockRepository = new MockRepository(0);
+    const paginateOpts = {
+        limit: 8,
+        page: 2,
+      };
+      const findCondition = {foo: 'bar'};
+
+    paginate<any>(mockRepository, {...paginateOpts}, findCondition);
+
+    expect(mockRepository.find).toHaveBeenCalledTimes(1);
+    expect(mockRepository.find).toHaveBeenCalledWith(expect.objectContaining({skip: 8, take: 8, where: findCondition}));
+    expect(mockRepository.count).toHaveBeenCalledTimes(1);
+    expect(mockRepository.count).toHaveBeenCalledWith(expect.objectContaining(findCondition));
+  });
+
   it('Item length should be correct', async () => {
     const mockRepository = new MockRepository(10);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,18 +1274,13 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, "chalk@^4.1.2 <5.0.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-chalk@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Actual fix for #614 

Note that you have both yarn.lock & package-lock.json. One should be removed.

Chalk v5 broke postinstall script.