### PR TITLE
Query caching feature

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -1,4 +1,3 @@
-import { async } from 'rxjs';
 import { Repository, FindManyOptions } from 'typeorm';
 
 export class MockRepository extends Repository<any> {

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -425,4 +425,46 @@ describe('Test paginate function', () => {
     expect(results.meta.totalItems).toBe(undefined);
     expect(results.meta.totalPages).toBe(undefined);
   });
+
+  it('Can call paginate with query caching set to true', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<any>(mockRepository, {
+      limit: 10,
+      page: 1,
+      cacheQueries: true,
+    });
+
+    expect(results).toBeInstanceOf(Pagination);
+    expect(results.items.length).toBe(10);
+  });
+
+  it('Can call paginate with query caching set to a number (milliseconds)', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<any>(mockRepository, {
+      limit: 10,
+      page: 1,
+      cacheQueries: 60000, // 1 min
+    });
+
+    expect(results).toBeInstanceOf(Pagination);
+    expect(results.items.length).toBe(10);
+  });
+
+  it('Can call paginate with query caching set to an object', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<any>(mockRepository, {
+      limit: 10,
+      page: 1,
+      cacheQueries: {
+        id: 'test',
+        milliseconds: 60000, // 1 min
+      },
+    });
+
+    expect(results).toBeInstanceOf(Pagination);
+    expect(results.items.length).toBe(10);
+  });
 });

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -42,7 +42,23 @@ export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
    * Turn off pagination count total queries. itemCount, totalItems, itemsPerPage and totalPages will be undefined
    */
   countQueries?: boolean;
+
+  /**
+   * @default false
+   * @link https://orkhan.gitbook.io/typeorm/docs/caching
+   *
+   * Enables or disables query result caching.
+   */
+  cacheQueries?: TypeORMCacheType;
 }
+
+export type TypeORMCacheType =
+  | boolean
+  | number
+  | {
+      id: any;
+      milliseconds: number;
+    };
 
 export interface ObjectLiteral {
   [s: string]: any;


### PR DESCRIPTION
Hello,
It's been a while since TypeORM introduced the [caching queries](https://github.com/typeorm/typeorm/blob/master/docs/caching.md) feature.

I tried to implement caching on the database layer while developing an application.
Then, I realized the `nestjs-typeorm-paginate` didn't cache the queries based on the typeorm global settings I set.

Also, another issue I ran into was I wanted to disable caching for a particular pagination query, and I couldn't set the `caching` option to `false`...

In this PR,
- I've added a new `cacheQueries` field to the pagination option and passed it to the TypeORM query builder while executing the queries.
- I've also updated the unit tests, and there is no breaking change!