### PR TITLE
fix: performance issue if orderBy() used in countQuery

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -248,7 +248,8 @@ const countQuery = async <T>(
     .skip(undefined)
     .limit(undefined)
     .offset(undefined)
-    .take(undefined);
+    .take(undefined)
+    .orderBy(undefined);
 
   const { value } = await queryBuilder.connection
     .createQueryBuilder()


### PR DESCRIPTION
If the ORDER BY used in the countQuery, it will excuse some performance issue.

This PR will remove the ORDER BY from the countQuery.