### PR TITLE
Fix some type mismatch, if there are no links

### DIFF
--- a/src/create-pagination.ts
+++ b/src/create-pagination.ts
@@ -73,13 +73,15 @@ export function createPaginationObject<
     currentPage: currentPage,
   };
 
+  const links = route ? routes : undefined;
+
   if (metaTransformer)
     return new Pagination<T, CustomMetaType>(
       items,
       metaTransformer(meta),
-      route && routes,
+      links,
     );
 
   // @ts-ignore
-  return new Pagination<T, CustomMetaType>(items, meta, route && routes);
+  return new Pagination<T, CustomMetaType>(items, meta, links);
 }


### PR DESCRIPTION
Since the `links` has the following type:

``` 
readonly items: PaginationObject[];
readonly meta: T;
readonly links?: IPaginationLinks;
```

And in some use case you can get the following response:
`const response = { items: [], meta: { ... },  links: "" }`

In the scope of this PR i'm gona totally remove the `links` property from the response object, because it's an optional property on the type definitions, and nothing to do with empty strings. `const response = { items: [], meta: { ... } }`.