### PR TITLE
fix: add nestjs 9.0.0 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepublish": "npm run format && npm run build"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.1.1 || ^5.6.2 || ^7.0.0 || ^8.0.0",
+    "@nestjs/common": "^6.1.1 || ^5.6.2 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "typeorm": "^0.3.0"
   },
   "jest": {


### PR DESCRIPTION
Fixes #749 

This PR adds `^9.0.0` to the peer deps for `@nestjs/common`. So this package can be used with version 9.
I have tested it quickly with a local project and it all appears to still work fine.