### PR TITLE
feat: implement count query type (RAW|ENTITY)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "paginate"
   ],
   "devDependencies": {
-    "@nestjs/common": "^7.5.5",
-    "@nestjs/core": "^7.5.5",
-    "@nestjs/testing": "^7.0.0",
-    "@nestjs/typeorm": "^7.1.0",
+    "@nestjs/common": "^9.0.0",
+    "@nestjs/core": "^9.0.0",
+    "@nestjs/testing": "^9.0.0",
+    "@nestjs/typeorm": "^9.0.0",
     "@types/jest": "^27.0.0",
     "@types/node": "^17.0.22",
     "coveralls": "^3.0.5",
@@ -29,7 +29,7 @@
     "mysql": "^2.17.1",
     "prettier": "^2.1.2",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^6.5.2",
+    "rxjs": "^7.1.0",
     "ts-jest": "^26.4.4",
     "ts-node": "^10.0.0",
     "typeorm": "0.3.6",

--- a/src/__tests__/base-orm-config.ts
+++ b/src/__tests__/base-orm-config.ts
@@ -1,9 +1,10 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { TestPivotEntity } from './test-pivot.entity';
 import { TestRelatedEntity } from './test-related.entity';
 import { TestEntity } from './test.entity';
 
 export const baseOrmConfigs: TypeOrmModuleOptions = {
-  entities: [TestEntity, TestRelatedEntity],
+  entities: [TestEntity, TestRelatedEntity, TestPivotEntity],
   host: 'localhost',
   port: 3306,
   type: 'mysql',

--- a/src/__tests__/paginate-raw-and-entities.spec.ts
+++ b/src/__tests__/paginate-raw-and-entities.spec.ts
@@ -4,6 +4,7 @@ import { Connection, QueryRunner, SelectQueryBuilder } from 'typeorm';
 import { paginateRawAndEntities } from '../paginate';
 import { Pagination } from '../pagination';
 import { baseOrmConfigs } from './base-orm-config';
+import { TestPivotEntity } from './test-pivot.entity';
 import { TestEntity } from './test.entity';
 
 describe('Test paginateRawAndEntities function', () => {
@@ -41,6 +42,16 @@ describe('Test paginateRawAndEntities function', () => {
       await queryBuilder
         .insert()
         .into(TestEntity)
+        .values({
+          id: i,
+        })
+        .execute();
+    }
+
+    for (let i = 1; i <= 3; i++) {
+      await queryBuilder
+        .insert()
+        .into(TestPivotEntity)
         .values({
           id: i,
         })

--- a/src/__tests__/paginate-raw.spec.ts
+++ b/src/__tests__/paginate-raw.spec.ts
@@ -4,6 +4,7 @@ import { Connection, QueryRunner, SelectQueryBuilder } from 'typeorm';
 import { paginateRaw } from '../paginate';
 import { Pagination } from '../pagination';
 import { baseOrmConfigs } from './base-orm-config';
+import { TestPivotEntity } from './test-pivot.entity';
 import { TestEntity } from './test.entity';
 
 interface RawQueryResult {
@@ -43,6 +44,16 @@ describe('Test paginateRaw function', () => {
       await queryBuilder
         .insert()
         .into(TestEntity)
+        .values({
+          id: i,
+        })
+        .execute();
+    }
+
+    for (let i = 1; i <= 3; i++) {
+      await queryBuilder
+        .insert()
+        .into(TestPivotEntity)
         .values({
           id: i,
         })

--- a/src/__tests__/test-pivot.entity.ts
+++ b/src/__tests__/test-pivot.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, ManyToMany, PrimaryColumn } from 'typeorm';
+import { TestEntity } from './test.entity';
+
+@Entity()
+export class TestPivotEntity {
+  @PrimaryColumn()
+  id: number;
+
+  @ManyToMany(() => TestEntity, (tests) => tests.testPivots)
+  tests: TestEntity[];
+}

--- a/src/__tests__/test.entity.ts
+++ b/src/__tests__/test.entity.ts
@@ -1,4 +1,5 @@
-import { PrimaryColumn, Entity, OneToMany } from 'typeorm';
+import { PrimaryColumn, Entity, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { TestPivotEntity } from './test-pivot.entity';
 import { TestRelatedEntity } from './test-related.entity';
 
 @Entity()
@@ -8,4 +9,18 @@ export class TestEntity {
 
   @OneToMany(() => TestRelatedEntity, (related) => related.test)
   related: TestRelatedEntity[];
+
+  @ManyToMany(() => TestPivotEntity, (testPivots) => testPivots.tests)
+  @JoinTable({
+    name: 'test_test_pivot',
+    joinColumn: {
+      name: 'testId',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'testPivotId',
+      referencedColumnName: 'id',
+    },
+  })
+  testPivots: TestPivotEntity[];
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,6 +3,11 @@ export enum PaginationTypeEnum {
   TAKE_AND_SKIP = 'take',
 }
 
+export enum CountQueryTypeEnum {
+  RAW = 'raw',
+  ENTITY = 'entity',
+}
+
 export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
   /**
    * @default 10
@@ -42,6 +47,12 @@ export interface IPaginationOptions<CustomMetaType = IPaginationMeta> {
    * Turn off pagination count total queries. itemCount, totalItems, itemsPerPage and totalPages will be undefined
    */
   countQueries?: boolean;
+
+  /**
+   * @default CountQueryTypeEnum.RAW
+   * Used for count query with countQuery(builder, cacheOptions) which is RAW or builder.getCount() which is ENTITY
+   */
+  countQueryType?: CountQueryTypeEnum;
 
   /**
    * @default false


### PR DESCRIPTION
This allows the query builder to choose a count query type which is counts for RAW or counts for ENTITY when an entity has inner join with many to many relations

ref issue #803 #758 

```typescript

import { Injectable } from '@nestjs/common';
import { Repository } from 'typeorm';
import { InjectRepository } from '@nestjs/typeorm';
import { CatEntity } from './entities';
import {
  paginate,
  Pagination,
  IPaginationOptions,
  CountQueryTypeEnum,
} from 'nestjs-typeorm-paginate';

@Injectable()
export class CatService {
  constructor(
    @InjectRepository(CatEntity)
    private readonly repository: Repository<CatEntity>,
  ) {}

  async paginate(): Promise<Pagination<CatEntity>> {
    return paginate<CatEntity>(this.repository, {
      page: 1,
      limit: 30,
      // default is CountQueryTypeEnum.RAW
      countQueryType: CountQueryTypeEnum.ENTITY,
    });
  }
}
```

<img width="493" alt="Screenshot 2022-11-27 at 00 10 17" src="https://user-images.githubusercontent.com/610443/204100659-e6f3db15-283b-4f5b-a784-3aecb1ec241d.png">