### PR TITLE
Use getCount() instead of raw count query

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -250,14 +250,5 @@ const countQuery = async <T>(
     .offset(undefined)
     .take(undefined)
     .orderBy(undefined);
-
-  const { value } = await queryBuilder.connection
-    .createQueryBuilder()
-    .select('COUNT(*)', 'value')
-    .from(`(${totalQueryBuilder.getQuery()})`, 'uniqueTableAlias')
-    .cache(cacheOption)
-    .setParameters(queryBuilder.getParameters())
-    .getRawOne<{ value: string }>();
-
-  return Number(value);
+  return totalQueryBuilder.getCount();
 };


### PR DESCRIPTION
The select count from query counts total rows returned. That returns an incorrect `total_items` value.

Should fix https://github.com/nestjsx/nestjs-typeorm-paginate/issues/758.
The regression was introduced https://github.com/nestjsx/nestjs-typeorm-paginate/pull/612