### PR TITLE
Fix counts for joined query builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     },
     "coverageDirectory": "../coverage"
   },
-  "version": "4.0.4",
+  "version": "4.1.0",
   "dependencies": {}
 }

--- a/src/__tests__/paginate.query.builder.distinct-count.spec.ts
+++ b/src/__tests__/paginate.query.builder.distinct-count.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getConnectionToken, TypeOrmModule } from '@nestjs/typeorm';
+import { Connection, QueryRunner } from 'typeorm';
+import { paginate } from '../paginate';
+import { baseOrmConfigs } from './base-orm-config';
+import { TestEntity } from './test.entity';
+import { TestRelatedEntity } from './test-related.entity';
+
+describe('Paginate counts with joins', () => {
+  let app: TestingModule;
+  let connection: Connection;
+  let runner: QueryRunner;
+
+  beforeAll(async () => {
+    app = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          ...baseOrmConfigs,
+          dropSchema: true,
+          synchronize: true,
+        }),
+      ],
+    }).compile();
+
+    connection = app.get(getConnectionToken());
+    runner = connection.createQueryRunner();
+
+    await runner.manager
+      .createQueryBuilder()
+      .insert()
+      .into(TestEntity)
+      .values([{ id: 1 }, { id: 2 }])
+      .execute();
+
+    await runner.manager
+      .createQueryBuilder()
+      .insert()
+      .into(TestRelatedEntity)
+      .values([
+        { id: 1, testId: 1 },
+        { id: 2, testId: 1 },
+        { id: 3, testId: 1 },
+        { id: 4, testId: 2 },
+      ])
+      .execute();
+  });
+
+  afterAll(async () => {
+    await runner.release();
+    await app.close();
+  });
+
+  it('counts distinct root entities even when joins duplicate rows', async () => {
+    const qb = runner.manager
+      .createQueryBuilder(TestEntity, 't')
+      .leftJoinAndSelect('t.related', 'r')
+      .orderBy('t.id', 'ASC');
+
+    const result = await paginate(qb, { limit: 10, page: 1 });
+
+    expect(result.items.map(({ id }) => id)).toEqual([1, 2]);
+    expect(result.meta.totalItems).toBe(2);
+    expect(result.meta.totalPages).toBe(1);
+  });
+});

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -249,15 +249,10 @@ const countQuery = async <T>(
     .limit(undefined)
     .offset(undefined)
     .take(undefined)
-    .orderBy(undefined);
+    .orderBy(undefined)
+    .cache(cacheOption);
 
-  const { value } = await queryBuilder.connection
-    .createQueryBuilder()
-    .select('COUNT(*)', 'value')
-    .from(`(${totalQueryBuilder.getQuery()})`, 'uniqueTableAlias')
-    .cache(cacheOption)
-    .setParameters(queryBuilder.getParameters())
-    .getRawOne<{ value: string }>();
-
-  return Number(value);
+  // Use TypeORM's built-in counting logic so joined queries de-duplicate
+  // on the primary key the same way `getMany` does.
+  return totalQueryBuilder.getCount();
 };


### PR DESCRIPTION
# Summary
- Fix pagination counts with joined query builders by relying on TypeORM's `getCount()` so totals are de-duplicated like `getMany`.
- Add a regression test that covers a join producing duplicate rows to ensure totals match the distinct root entities.

# Problem
- The library cloned the query builder and ran `SELECT COUNT(*) FROM (<join query>)` for totals.
- When joins multiply rows per entity (e.g., many-to-many or one-to-many), the page results were distinct but the total used the raw row count, inflating `totalItems/totalPages` and creating empty pages.

# Change
- Clear pagination/order clauses on the cloned builder and call `getCount()`; TypeORM injects the same DISTINCT-on-PK logic used for paged selects.
- Added `paginate.query.builder.distinct-count.spec.ts` to prove joined queries now report correct totals.

# Side Effects / Compatibility
- Totals on joined queries will drop to the correct distinct-entity count; if any consumers relied on the old overcounted totals, they will see smaller numbers (desired fix).
- Behavior now follows TypeORM `getCount()` semantics (e.g., honors `groupBy` the same way TypeORM does) and still issues one count query plus one data query.
