### PR TITLE
fix: reject a limit of 0 instead of dividing totalPages by zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     },
     "coverageDirectory": "../coverage"
   },
-  "version": "4.0.4",
+  "version": "4.1.0",
   "dependencies": {}
 }

--- a/src/__tests__/paginate.repository.spec.ts
+++ b/src/__tests__/paginate.repository.spec.ts
@@ -235,6 +235,57 @@ describe('Test paginate function', () => {
     );
   });
 
+  it('replaces a limit of 0 with the default of 10', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const consoleMock = jest
+      .spyOn(console, 'warn')
+      .mockImplementationOnce(() => {});
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 0,
+      page: 1,
+      route: 'http://example.com/something',
+    });
+
+    expect(results.items.length).toBe(10);
+    expect(results.meta.itemsPerPage).toBe(10);
+    expect(results.meta.totalPages).toBe(1);
+    expect(results.links?.last).toBe(
+      'http://example.com/something?page=1&limit=10',
+    );
+    expect(consoleMock).toHaveBeenCalledWith(
+      'Query parameter "limit" with value "0" was resolved as "0", please validate your query input! Falling back to default "10".',
+    );
+  });
+
+  it('keeps totalPages serialisable when limit is 0', async () => {
+    const mockRepository = new MockRepository(10);
+
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 0,
+      page: 1,
+    });
+
+    // Dividing by a limit of 0 used to yield Infinity, which JSON.stringify
+    // turns into null by the time it reaches an API consumer.
+    expect(JSON.parse(JSON.stringify(results.meta)).totalPages).toBe(1);
+  });
+
+  it('still accepts a page of 0', async () => {
+    const mockRepository = new MockRepository(10);
+
+    const results = await paginate<Entity>(mockRepository, {
+      limit: 4,
+      page: 0,
+    });
+
+    expect(results.items.length).toBe(0);
+    expect(results.meta.currentPage).toBe(0);
+  });
+
   it('replaces an alphabetic page with the default of 1', async () => {
     const mockRepository = new MockRepository(10);
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -147,7 +147,12 @@ function resolveNumericOption(
   const value = options[key];
   const resolvedValue = Number(value);
 
-  if (Number.isInteger(resolvedValue) && resolvedValue >= 0)
+  // A `page` of 0 is meaningful — paginate resolves it to an empty page — but
+  // a `limit` of 0 makes totalPages a division by zero, which surfaces as
+  // `Infinity` (or `NaN` with no results) and serialises to null over JSON.
+  const minimum = key === 'limit' ? 1 : 0;
+
+  if (Number.isInteger(resolvedValue) && resolvedValue >= minimum)
     return resolvedValue;
 
   console.warn(


### PR DESCRIPTION
## Summary

A `limit` of 0 is currently accepted, and it makes `totalPages` a division by zero. `resolveNumericOption` guards with `resolvedValue >= 0`, so `0` passes straight through to `Math.ceil(totalItems / limit)`.

Reproduced against a repository holding 10 entities:

```js
await paginate(repo, { limit: 0, page: 1, route: '/t' })
```

```json
meta:  { "totalItems": 10, "itemCount": 0, "itemsPerPage": 0, "totalPages": null, "currentPage": 1 }
links: { "first": "/t?limit=0", "previous": "", "next": "/t?page=2&limit=0", "last": "/t?page=Infinity&limit=0" }
```

Two things go wrong there. `totalPages` is `Infinity`, which `JSON.stringify` writes as `null`, so an API consumer sees a null where a number is documented. And `links.last` becomes `?page=Infinity&limit=0`, which is not a usable URL.

With no results at all it is `NaN / 0` instead, which also serialises to `null`.

This matters because `limit` usually arrives straight off a query string, and `?limit=0` is an easy thing for a caller to send.

## The fix

`resolveNumericOption` now applies a minimum of 1 to `limit` while leaving `page` at 0:

```ts
const minimum = key === 'limit' ? 1 : 0;
```

A `limit` of 0 therefore takes the existing invalid-input path — the warning that is already in place fires, and it falls back to the default of 10. That felt more consistent than throwing, since the function already treats `'x'`, `1.5` and negatives that way.

`page` is deliberately untouched. `paginateRepository` has an explicit `page < 1` branch that returns an empty pagination object, and there are tests covering it, so 0 stays valid there. I added a test pinning that down so the distinction does not get lost later.

## Tests

Three added to `paginate.repository.spec.ts`:

- `replaces a limit of 0 with the default of 10` — covers the items, the meta and the warning
- `keeps totalPages serialisable when limit is 0` — round-trips the meta through `JSON.parse(JSON.stringify(...))`, which is where the `Infinity` actually bites
- `still accepts a page of 0` — guards the behaviour I did not want to change

The first two fail before the change and pass after:

```
before:  Tests: 2 failed, 25 passed, 27 total
after:   Tests: 27 passed, 27 total
```

One caveat on how I verified this. I ran the mock-backed suites (`paginate.repository.spec`, `paginate.meta.transform.spec`) and `tsc --noEmit`, both clean. I did not run the MySQL-backed suites, since I did not have the container up. The change is confined to `resolveNumericOption`, which every entry point shares, so I would not expect it to reach them differently — but worth a look on your side before merging.

While setting up I noticed `docker-compose.yml` reads `env_file: .env` and the repo ships `.env.dist`, with no note in the README about copying it. Happy to send a short "running the tests" section separately if that would save the next person the detour.
